### PR TITLE
[의존성] Auction_chat_name 과 product 의 의존성 수정

### DIFF
--- a/auction/models.py
+++ b/auction/models.py
@@ -5,18 +5,16 @@ from product.models import Products
 
 
 """
-auction_id : 경매가 진행되는 실시간 채팅방 고유 번호 / pk로 잡혀서 따로 필요 없을듯
 auction_users : 경매 물건을 파는 사람 == 채팅방 주인
-auction_chat_name : 경매 채팅방 이름(경매 제품 이름)
+auction_chat_name : 경매 채팅방 이름(경매 제품 이름) // 제품 당 1개의 채팅방만 생성가능(1:1)
 auction_chat_open_at : 경매 시작 시간
 auction_chat_close_at : 경매 마감 시간(user가 경매를 종료 했을 경우 마감 시간이 설정 됨)
 """
 
 
 class Auction(models.Model):
-    # auction_id = models.AutoField(primary_key=True)
     auction_users = models.ForeignKey(User, on_delete=models.CASCADE)
-    auction_chat_name = models.ForeignKey(Products, on_delete=models.CASCADE)
+    auction_chat_name = models.OneToOneField(Products, on_delete=models.CASCADE)
     auction_chat_open_at = models.DateTimeField(blank=False)
     auction_chat_close_at = models.DateTimeField(blank=True, null=True)
 


### PR DESCRIPTION
## 반영 브랜치
suhyun -> develop

---

## 변경 사항

auction_chat_name 을 ForeignKey 에서 OneToOneField로 수정하였습니다.
(경매 제품과 경매 채팅방은 1:1 관계로 되어야 함)

### 이전 코드
```py
auction_chat_name = models.ForeignKey(Products, on_delete=models.CASCADE)
```

### 변경 코드
```py
auction_chat_name = models.OneToOneField(Products, on_delete=models.CASCADE)
```
