### PR TITLE
[오류 수정] 로그인 시 password 참조 오류 해결

### DIFF
--- a/user/urls.py
+++ b/user/urls.py
@@ -3,8 +3,8 @@ from django.urls import path
 from user import views
 
 urlpatterns = [
-    path("sms/", views.CheckPhoneNumberView.as_view(), name="send-sms"),
-    path("auth/", views.CheckAuthNumberView.as_view(), name="check-auth-number"),
-    path("signup/", views.SignUpView.as_view(), name="signup"),
-    path("login/", views.LoginView.as_view(), name="login"),
+    path("sms", views.CheckPhoneNumberView.as_view(), name="send-sms"),
+    path("auth", views.CheckAuthNumberView.as_view(), name="check-auth-number"),
+    path("signup", views.SignUpView.as_view(), name="signup"),
+    path("login", views.LoginView.as_view(), name="login"),
 ]

--- a/user/views.py
+++ b/user/views.py
@@ -60,9 +60,10 @@ class CheckAuthNumberView(APIView):
         phone_number = request.data["phone_number"]
         input_number = request.data["input_number"]
 
-        user_check = User.objects.filter(phone_number=phone_number).exists()
-        if user_check:
-            if user_check.auth_number == input_number:
+        user_check = User.objects.filter(phone_number=phone_number)
+        
+        if user_check.exists():
+            if user_check.first().auth_number == input_number:
                 return Response({"msg": "인증이 완료되었습니다."}, status=status.HTTP_200_OK)
             else:
                 return Response(
@@ -95,22 +96,19 @@ class LoginView(APIView):
         phone_number = request.data["phone_number"]
         password = request.data["password"]
 
-        user_check = (
-            User.objects.filter(phone_number=phone_number).exists()
-        )
+        user_check = User.objects.filter(phone_number=phone_number)
 
-        if not user_check:
+        if not user_check.exists():
             return Response(
                 {"msg": "존재하지 않는 유저입니다."}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        if not check_password(password, user_check.password):
+        if not check_password(password, user_check.first().password):
             return Response(
                 {"msg": "비밀번호가 일치하지 않습니다."}, status=status.HTTP_400_BAD_REQUEST
             )
 
         user = authenticate(phone_number=phone_number, password=password)
-        print(user)
 
         if user.is_authenticated:
             token = MyTokenObtainPairSerializer.get_token(user)
@@ -119,5 +117,5 @@ class LoginView(APIView):
 
             return Response(
                 {"msg": "로그인 성공", "access": access_token, "refresh": refresh_token},
-                status=status.HTTP_200_OK,
+                status=status.HTTP_200_OK
             )


### PR DESCRIPTION
## 반영 브랜치
jeongyoon -> develop

## 변경 사항
오류 : 로그인 시 저장된 유저의 password를 불러오는 과정에서 오류 발생
> user_check를 filter로 가져오고, 필요에 맞게 exists()와 first()로 구분해주었습니다.

변경 전
```python
user_check = User.objects.filter(phone_number=phone_number).exists()

        if not user_check:
            return Response(
                {"msg": "존재하지 않는 유저입니다."}, status=status.HTTP_400_BAD_REQUEST
            )

        if not check_password(password, user_check.password):
            return Response(
                {"msg": "비밀번호가 일치하지 않습니다."}, status=status.HTTP_400_BAD_REQUEST
            )
```
변경 후
```python
user_check = User.objects.filter(phone_number=phone_number)

        if not user_check.exists():
            return Response(
                {"msg": "존재하지 않는 유저입니다."}, status=status.HTTP_400_BAD_REQUEST
            )

        if not check_password(password, user_check.first().password):
            return Response(
                {"msg": "비밀번호가 일치하지 않습니다."}, status=status.HTTP_400_BAD_REQUEST
            )
```
