### PR TITLE
[기능 변경] 판매자가 경매 시작 시점 결정

### DIFF
--- a/config/tests/product/test_models.py
+++ b/config/tests/product/test_models.py
@@ -1,0 +1,53 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from product.models import Products, Categories
+from django.utils import timezone
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+import pytest
+
+pytestmark = pytest.mark.django_db
+User = get_user_model()
+
+
+class TestProductsModel:
+    def test_str_method(self, products_factory):
+        x = products_factory(product_name="test")
+        assert x.__str__() == "test"
+
+    def test_set_auction_active_method(
+        self, user_factory, categories_factory, products_factory
+    ):
+        current_datetime = timezone.now()
+        past_datetime = current_datetime - timezone.timedelta(days=5)
+
+        category = categories_factory(category_name="TestCategory")
+        product = products_factory(
+            seller_id=user_factory(
+                username="testuser",
+                phone_number="01012341234",
+                nickname="user_name",
+                address="address",
+                profile_image="asdasd.jpg",
+                password="password",
+            ),
+            product_name="TestProduct",
+            product_price="100",
+            product_content="Test content",
+            auction_start_at=current_datetime,
+            auction_end_at=past_datetime,
+            category=category,
+        )
+        assert not product.auction_active
+
+    # # set_auction_active 메서드를 직접 호출하여 auction_active가 False로 설정되었는지 확인
+    #     product.set_auction_active()
+    #     product.refresh_from_db()
+    #     self.assertFalse(product.auction_active)
+
+    #     # auction_end_at를 미래로 설정하고 set_auction_active 메서드를 호출하여 auction_active가 True로 설정되었는지 확인
+    #     future_datetime = timezone.now() + timezone.timedelta(days=5)
+    #     product.auction_end_at = future_datetime
+    #     product.set_auction_active()  # save 메서드 호출 제거
+    #     product.refresh_from_db()
+    #     self.assertTrue(product.auction_active)

--- a/product/models.py
+++ b/product/models.py
@@ -11,12 +11,10 @@ from django.dispatch import receiver
 class Products(models.Model):
     seller_id = models.ForeignKey(User, on_delete=models.CASCADE)
     product_name = models.CharField(max_length=100)
-    product_price = models.CharField(max_length=100)
+    product_price = models.IntegerField()
     product_content = models.TextField()
-    auction_start_at = models.DateTimeField(default=timezone.now)
-    auction_end_at = models.DateTimeField(
-        default=timezone.now() + timezone.timedelta(days=3)
-    )
+    auction_start_at = models.DateTimeField(blank=True, null=True)
+    auction_end_at = models.DateTimeField(blank=True, null=True)
     auction_active = models.BooleanField(default=True)
     category = TreeForeignKey("Categories", on_delete=models.PROTECT)
 

--- a/product/views.py
+++ b/product/views.py
@@ -62,6 +62,9 @@ class NewProductView(APIView):
     def post(self, request):
         serializer = ProductsSerializer(data=request.data)
         if serializer.is_valid():
+            current_date = serializer.validated_data["auction_start_at"]
+            final_date = current_date + timezone.timedelta(days=3)
+            serializer.validated_data["auction_end_at"] = final_date
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
- 경매가 자동으로 시작되는 것이 아닌 판매자가 결정하는 것으로 변경되었습니다.
- 경매가 시작되는 지점에서 3일 후 자동으로 경매상태가 false로 변경 됩니다.
- 이전에 price 부분 char -> int 로 변경 되었습니다.

변경 전
models.py

```python
product_price = models.CharField(max_length=100)
auction_start_at = models.DateTimeField(default=timezone.now)
auction_end_at = models.DateTimeField(
        default=timezone.now() + timezone.timedelta(days=3)
)
```
변경 후
```python
product_price = models.IntegerField()
auction_start_at = models.DateTimeField(blank=True, null=True)
auction_end_at = models.DateTimeField(blank=True, null=True)
```

변경 전
views.py

```python
    def post(self, request):
        serializer = ProductsSerializer(data=request.data)
        if serializer.is_valid():
            serializer.save()
            return Response(serializer.data, status=status.HTTP_201_CREATED)
        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
```

변경 후
```python
    def post(self, request):
        serializer = ProductsSerializer(data=request.data)
        if serializer.is_valid():
            current_date = serializer.validated_data["auction_start_at"]
            final_date = current_date + timezone.timedelta(days=3)
            serializer.validated_data["auction_end_at"] = final_date
            serializer.save()
            return Response(serializer.data, status=status.HTTP_201_CREATED)
        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
```