### PR TITLE
[버그 수정] product 모델 무한 루프 버그 수정

### DIFF
--- a/product/models.py
+++ b/product/models.py
@@ -23,10 +23,11 @@ class Products(models.Model):
         verbose_name_plural = "Products"
 
     @receiver(post_save, sender="product.Products")
-    def set_auction_active(sender, instance, **kwargs):
-        if not instance.auction_end_at or instance.auction_end_at < timezone.now():
-            instance.auction_active = False
-            instance.save()
+    def set_auction_active(sender, instance, created, **kwargs):
+        if created:
+            if not instance.auction_end_at or instance.auction_end_at < timezone.now():
+                instance.auction_active = False
+                instance.save(update_fields=["auction_active"])
 
     def __str__(self):
         return self.product_name


### PR DESCRIPTION
## 반영 브랜치
suhyun -> develop

---
## 이슈 사항
어드민 패널에서 따로 product 객체를 생성할 때
set_auction_active 함수가 instance.save() 를 호출 하면서 post_save 로 다시 트리거 되어 무한루프 발생되는 이슈가 생겼습니다.


---
## 변경 사항
1. 객체가 생성될 때만 실행되도록 변경
2. update_fields를 사용하여 auction_active 필드만 저장되도록 변경
3. 그 외의 경우에는 auction_active가 활성화되지 않음


ssu-uky 님이 제안해주신 코드를 검토했고 문제가 없어서 제안해주신 코드로 이전 코드를 수정했습니다.
변경된 코드는 다음과 같습니다.

변경 전 코드

```python
    @receiver(post_save, sender="product.Products")
    def set_auction_active(sender, instance, **kwargs):
        if not instance.auction_end_at or instance.auction_end_at < timezone.now():
            instance.auction_active = False
            instance.save()
```

변경 후 
```python
    @receiver(post_save, sender="product.Products")
    def set_auction_active(sender, instance, created, **kwargs):
        if created:
            if not instance.auction_end_at or instance.auction_end_at < timezone.now():
                instance.auction_active = False
                instance.save(update_fields=["auction_active"])

```
