### PR TITLE
[기능 추가] Penalty API 추가

### DIFF
--- a/auction/tasks.py
+++ b/auction/tasks.py
@@ -24,6 +24,8 @@ def check_and_create_auction_rooms():
             if auction_room_check.auction_end_at <= timezone.now():
                 auction_room_check.auction_active = False
                 auction_room_check.save()
+                product.product_active = False
+                product.save()
             
         except:
             #product 등록 시 auction_end_at을 지정하지 않았다면 default값으로 설정

--- a/config/settings.py
+++ b/config/settings.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import os
 import environ
 from datetime import timedelta
+from celery.schedules import crontab
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 
@@ -90,6 +91,11 @@ CELERY_BEAT_SCHEDULE = {
     "check-auction-start-times": {
         "task": "auction.tasks.check_and_create_auction_rooms",
         "schedule": timedelta(seconds=10),
+    },
+    
+    "check_and_give_buy_penalty": {
+        "task": "penalty.tasks.check_and_give_buy_penalty",
+        "schedule": crontab(minute=0, hour=0),
     },
 }
 

--- a/penalty/admin.py
+++ b/penalty/admin.py
@@ -1,3 +1,4 @@
 from django.contrib import admin
+from penalty.models import Penalty
 
-# Register your models here.
+admin.site.register(Penalty)

--- a/penalty/admin.py
+++ b/penalty/admin.py
@@ -1,4 +1,12 @@
 from django.contrib import admin
 from penalty.models import Penalty
 
-admin.site.register(Penalty)
+
+@admin.register(Penalty)
+class PenaltyAdmin(admin.ModelAdmin):
+    list_display = [
+        "user_id",
+        "penalty_type",
+        "penalty_content",
+        "penalty_date",
+    ]

--- a/penalty/apps.py
+++ b/penalty/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class PenaltyConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'penalty'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "penalty"

--- a/penalty/models.py
+++ b/penalty/models.py
@@ -10,3 +10,4 @@ class Penalty(models.Model):
     user_id = models.ForeignKey(User,  on_delete=models.CASCADE)
     penalty_type = models.CharField(max_length=4,choices=PeanaltyTypeChoice.choices)
     penalty_content = models.TextField()
+    penalty_date = models.DateTimeField(auto_now_add=True)

--- a/penalty/models.py
+++ b/penalty/models.py
@@ -2,12 +2,13 @@ from django.db import models
 
 from user.models import User
 
+
 class Penalty(models.Model):
     class PeanaltyTypeChoice(models.TextChoices):
-        BUY = 'buy','구매'
-        SELL = 'sell','판매'
-    
-    user_id = models.ForeignKey(User,  on_delete=models.CASCADE)
-    penalty_type = models.CharField(max_length=4,choices=PeanaltyTypeChoice.choices)
+        BUY = "buy", "구매"
+        SELL = "sell", "판매"
+
+    user_id = models.ForeignKey(User, on_delete=models.CASCADE)
+    penalty_type = models.CharField(max_length=4, choices=PeanaltyTypeChoice.choices)
     penalty_content = models.TextField()
     penalty_date = models.DateTimeField(auto_now_add=True)

--- a/penalty/serializers.py
+++ b/penalty/serializers.py
@@ -1,0 +1,18 @@
+from rest_framework import serializers
+from penalty.models import Penalty
+
+class PenaltySerializer(serializers.ModelSerializer):
+    buy_penalties_count = serializers.SerializerMethodField(read_only=True)
+    sell_penalties_count = serializers.SerializerMethodField(read_only=True)
+    
+    def get_buy_penalties_count(self, obj):
+        return Penalty.objects.filter(penalty_type='buy').count()
+    
+    def get_sell_penalties_count(self, obj):
+        return Penalty.objects.filter(penalty_type='sell').count()
+    
+    class Meta:
+        model = Penalty
+        fields = '__all__'
+        read_only_fields = ["user_id",]
+        

--- a/penalty/serializers.py
+++ b/penalty/serializers.py
@@ -6,10 +6,10 @@ class PenaltySerializer(serializers.ModelSerializer):
     sell_penalties_count = serializers.SerializerMethodField(read_only=True)
     
     def get_buy_penalties_count(self, obj):
-        return Penalty.objects.filter(penalty_type='buy').count()
+        return Penalty.objects.filter(user_id = obj.user_id, penalty_type='buy').count()
     
     def get_sell_penalties_count(self, obj):
-        return Penalty.objects.filter(penalty_type='sell').count()
+        return Penalty.objects.filter(user_id = obj.user_id, penalty_type='sell').count()
     
     class Meta:
         model = Penalty

--- a/penalty/serializers.py
+++ b/penalty/serializers.py
@@ -1,18 +1,20 @@
 from rest_framework import serializers
 from penalty.models import Penalty
 
+
 class PenaltySerializer(serializers.ModelSerializer):
     buy_penalties_count = serializers.SerializerMethodField(read_only=True)
     sell_penalties_count = serializers.SerializerMethodField(read_only=True)
-    
+
     def get_buy_penalties_count(self, obj):
-        return Penalty.objects.filter(user_id = obj.user_id, penalty_type='buy').count()
-    
+        return Penalty.objects.filter(user_id=obj.user_id, penalty_type="buy").count()
+
     def get_sell_penalties_count(self, obj):
-        return Penalty.objects.filter(user_id = obj.user_id, penalty_type='sell').count()
-    
+        return Penalty.objects.filter(user_id=obj.user_id, penalty_type="sell").count()
+
     class Meta:
         model = Penalty
-        fields = '__all__'
-        read_only_fields = ["user_id",]
-        
+        fields = "__all__"
+        read_only_fields = [
+            "user_id",
+        ]

--- a/penalty/tasks.py
+++ b/penalty/tasks.py
@@ -1,0 +1,28 @@
+from celery import shared_task
+from datetime import timedelta
+from django.utils import timezone
+from django.core.exceptions import ObjectDoesNotExist
+
+from auction.models import AuctionRoom
+from penalty.models import Penalty
+
+
+@shared_task
+def check_and_give_buy_penalty():
+    # 매일 자정 상품의 결제 상태 체크
+    not_paid_auction_rooms = AuctionRoom.objects.filter(
+        auction_active=False, payment_active=True
+    )
+
+    for room in not_paid_auction_rooms:
+        # 경매가 끝난 후 3일이 지나도 payment_active가 true인 경우 패널티 부여
+        if timezone.now() > room.auction_room_name.auction_end_at + timedelta(days=3):
+            Penalty.objects.create(
+                user_id=room.auction_winner,
+                penalty_type="buy",
+                penalty_content=f"{room.auction_room_name} 기간 안에 결제를 하지 않았습니다.",
+            )
+            room.payment_active = False
+            room.save()
+
+    return "check buy penalty"

--- a/penalty/urls.py
+++ b/penalty/urls.py
@@ -1,5 +1,7 @@
 from django.urls import path
-from django.conf import settings
+
+from penalty import views
 
 urlpatterns = [ 
+    path("<int:user_id>", views.PenaltyView.as_view(), name="penalty"),
 ]

--- a/penalty/urls.py
+++ b/penalty/urls.py
@@ -2,6 +2,6 @@ from django.urls import path
 
 from penalty import views
 
-urlpatterns = [ 
+urlpatterns = [
     path("<int:user_id>", views.PenaltyView.as_view(), name="penalty"),
 ]

--- a/penalty/views.py
+++ b/penalty/views.py
@@ -22,7 +22,7 @@ class PenaltyView(APIView):
 
     def post(self, request, user_id):
         serializer = PenaltySerializer(data=request.data)
-        if serializer.is_vaid():
-            serializer.save(user_id=user_id)
+        if serializer.is_valid():
+            serializer.save(user_id=request.user)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/penalty/views.py
+++ b/penalty/views.py
@@ -6,20 +6,23 @@ from rest_framework.permissions import IsAuthenticated
 from penalty.serializers import PenaltySerializer
 from penalty.models import Penalty
 
+
 class PenaltyView(APIView):
-    '''
+    """
     get : 마이페이지에서 유저가 받은 페널티 내역 확인
     post : 유저에게 패널티 부여
-    '''
+    """
+
     permission_classes = [IsAuthenticated]
+
     def get(self, request, user_id):
         penalties = Penalty.objects.filter(user_id=user_id)
         serializer = PenaltySerializer(penalties, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
-    
+
     def post(self, request, user_id):
-        serializer = PenaltySerializer(data = request.data)
+        serializer = PenaltySerializer(data=request.data)
         if serializer.is_vaid():
             serializer.save(user_id=user_id)
-            return Response(serializer.data, status=status.HTTP_201_CREATED )
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/penalty/views.py
+++ b/penalty/views.py
@@ -1,3 +1,25 @@
-from django.shortcuts import render
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
 
-# Create your views here.
+from penalty.serializers import PenaltySerializer
+from penalty.models import Penalty
+
+class PenaltyView(APIView):
+    '''
+    get : 마이페이지에서 유저가 받은 페널티 내역 확인
+    post : 유저에게 패널티 부여
+    '''
+    permission_classes = [IsAuthenticated]
+    def get(self, request, user_id):
+        penalties = Penalty.objects.filter(user_id=user_id)
+        serializer = PenaltySerializer(penalties, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+    
+    def post(self, request, user_id):
+        serializer = PenaltySerializer(data = request.data)
+        if serializer.is_vaid():
+            serializer.save(user_id=user_id)
+            return Response(serializer.data, status=status.HTTP_201_CREATED )
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/product/admin.py
+++ b/product/admin.py
@@ -13,7 +13,7 @@ class ProductImagesInline(admin.TabularInline):
 class ProductsAdminForm(forms.ModelForm):
     class Meta:
         model = Products
-        exclude = ("auction_end_at",)
+        fields="__all__"
 
 
 class ProductsAdmin(admin.ModelAdmin):
@@ -24,6 +24,7 @@ class ProductsAdmin(admin.ModelAdmin):
         "product_price",
         "auction_start_at",
         "product_active",
+        "auction_end_at"
     )
     list_filter = ("seller_id", "product_active")
     search_fields = ("product_name", "seller_id__username")

--- a/user/admin.py
+++ b/user/admin.py
@@ -1,3 +1,4 @@
 from django.contrib import admin
+from user.models import User
 
-# Register your models here.
+admin.site.register(User)


### PR DESCRIPTION
## 반영 브랜치
jeongyoon --> develop

---

## 기능 추가 사항
**1. 패널티 기록 조회 - GET (PenaltyView)** 
- penalties/<int: user_id>
- 본인의 패널티만 조회 가능, 로그인 필수

**2. 수동 패널티 부여 - POST (PenaltyView)**
- penalties/<int: user_id>
- type에 따라 구매/판매 패널티 부여 가능

**3. 자동 구매 패널티 부여**
- 결제 기한 내에 결제를 하지 않았을 경우 구매 패널티 부여
---

## 핵심 로직 
```python
#penalty/tasks.py
@shared_task
def check_and_give_buy_penalty():
    # 매일 자정 상품의 결제 상태 체크
    not_paid_auction_rooms = AuctionRoom.objects.filter(
        auction_active=False, payment_active=True
    )

    for room in not_paid_auction_rooms:
        # 경매가 끝난 후 3일이 지나도 payment_active가 true인 경우 패널티 부여
        if timezone.now() > room.auction_room_name.auction_end_at + timedelta(days=3):
            Penalty.objects.create(
                user_id=room.auction_winner,
                penalty_type="buy",
                penalty_content=f"{room.auction_room_name} 기간 안에 결제를 하지 않았습니다.",
            )
            #  패널티 부여 후 해당 경매방은 결제 불가 상태로 변경
            room.payment_active = False
            room.save()
```
---

##  테스트 
**1. PenaltyView GET**
![image](https://github.com/wodnrP/realtime_auction/assets/109218139/6205f05f-e72d-4f5e-bfa4-d492c2e2907b)

**2. PenaltyView POST**
![image](https://github.com/wodnrP/realtime_auction/assets/109218139/ec6de6b8-c008-4ac0-bccb-5c16a4a69e54)
